### PR TITLE
Don't double print very latest log

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func displayLogs(args []string, options map[string]string) int {
 	var ctx context.Context
 	var client osc.APIClient
 	var callsToIgnore []string
+	var lastRequestId string
 	if options["profile"] != "" {
 		_, ctx, client, err = GenerateConfigurationAndContext(options["profile"])
 	} else {
@@ -98,6 +99,9 @@ func displayLogs(args []string, options map[string]string) int {
 			continue
 		}
 		for _, log := range logs {
+			if log.GetRequestId() == lastRequestId {
+				continue
+			}
 			if SearchByCallName(log, callsToIgnore) {
 				continue
 			}
@@ -120,6 +124,7 @@ func displayLogs(args []string, options map[string]string) int {
 		}
 
 		lastLog := logs[len(logs)-1]
+		lastRequestId = lastLog.GetRequestId()
 		logDate = *lastLog.QueryDate
 		go func() {
 			<-stopSignal


### PR DESCRIPTION
QueryAfterDate filter take into account equality so we have a duplicate log.
In this commit, we record latest request identifier and avoid printing it again.

closes #22

Signed-off-by: Jérôme Jutteau <jerome.jutteau@outscale.com>